### PR TITLE
fix: Allow optional config values

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -12,6 +12,7 @@ PLEXOSConfig(e::Node, ::AbstractDataset) = PLEXOSConfig(
     getchildtext("value", e)
 )
 
+PLEXOSConfig(e::String, ::Nothing) = PLEXOSConfig(e, "")
 
 struct PLEXOSUnit
     value::String


### PR DESCRIPTION
Some values in PLEXOS's config are empty values, e.g.:

```
  <t_config>
    <element>Owners</element>
    <value />
  </t_config>

...

  <t_config>
    <element>AltNameColumns</element>
    <value />
  </t_config>
```

This fix makes H5PLEXOS parse that correctly