### PR TITLE
fix: Allow `Period0` and `Period1` to parse missing quarter_id

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -321,7 +321,7 @@ PLEXOSPeriod0(e::Node, d::AbstractDataset) =
                   getchildint("day_id", e),
                   getchildint("week_id", e),
                   getchildint("month_id", e),
-                  getchildint("quarter_id", e),
+                  something(getchildint("quarter_id", e), 0),
                   getchildint("fiscal_year_id", e),
                   getchildtext("datetime", e))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -337,7 +337,7 @@ end
 PLEXOSPeriod1(e::Node, d::AbstractDataset) =
     PLEXOSPeriod1(getchildint("week_id", e),
                   getchildint("month_id", e),
-                  getchildint("quarter_id", e),
+                  something(getchildint("quarter_id", e), 0),
                   getchildint("fiscal_year_id", e),
                   getchildtext("date", e))
 


### PR DESCRIPTION
Fixes #8 